### PR TITLE
draft: revamp file structure 1

### DIFF
--- a/src/dom_core/mod.ts
+++ b/src/dom_core/mod.ts
@@ -1,7 +1,5 @@
 export type { HTMLElementUniqueMemberKeys, HTMLEventNames, HTMLTagNames, SVGEventNames, SVGTagNames } from "../deps.ts"
 export type { HTMLTagNameAttributesMap } from "./html_attributes_map.ts"
-export { inlinePropsRemapper } from "./inline_convenience.ts"
-export type { InlineAttrName, InlineEventName, InlineExecuteFn, InlineExecuteName, InlineMemberName } from "./inline_convenience.ts"
 export type { SVGTagNameAttributesMap } from "./svg_attributes_map.ts"
 import type { HTMLTagNames, SVGTagNames } from "../deps.ts"
 import type { IntrinsicElements } from "../tsignal/mod.ts"

--- a/src/funcdefs.ts
+++ b/src/funcdefs.ts
@@ -1,4 +1,5 @@
-import { ADVANCED_EVENTS, ATTRS, AttrProps, AttrValue, EVENTS, MEMBERS, Props, EXECUTE, Stringifiable, STYLE } from "./typedefs.ts"
+import { ADVANCED_EVENTS, ATTRS, AttrProps, EVENTS, EXECUTE, MEMBERS, STYLE } from "./symbol_props.ts"
+import { AttrValue, Props, Stringifiable } from "./typedefs.ts"
 
 
 export const

--- a/src/hyperzone.ts
+++ b/src/hyperzone.ts
@@ -1,9 +1,16 @@
 import { DEBUG, console_error } from "./deps.ts"
+import type { Context } from "./tsignal_base/deps.ts"
 import { Fragment, HyperRender } from "./typedefs.ts"
 
 
 type HyperZoneChild = typeof PushZone | typeof PopZone | Node
 type HyperZoneChildren = (HyperZoneChild | Array<HyperZoneChild>)[]
+// type RenderGroupLibraries = "vanilla" | "tsignal" | "react" | "solid"
+export interface HyperZoneContext {
+	vanilla?: undefined
+	tsignal?: { ctx: Context }
+	react?: { createElement: any }
+}
 
 const
 	PushZone = Symbol(DEBUG.MINIFY || "pushed a zone"),
@@ -11,6 +18,7 @@ const
 	node_only_child_filter = (child: symbol | Node) => (typeof child !== "symbol")
 
 export class HyperZone extends HyperRender<any, any> {
+	public ctx: HyperZoneContext = {}
 	protected zones: Array<HyperRender[]> = []
 
 	constructor(...default_zone: HyperRender[]) {

--- a/src/inline_props.ts
+++ b/src/inline_props.ts
@@ -1,9 +1,10 @@
 /** this module defines a set of convenient inline attribute/property naming guide */
 
-import { number_parseInt, object_assign, object_entries, object_fromEntries, type HTMLElementUniqueMemberKeys, type HTMLEventNames, type HTMLTagNames, type SVGEventNames, type SVGTagNames, } from "../deps.ts"
-import { ATTRS, EVENTS, EXECUTE, MEMBERS, STYLE, type AdvancedEventFn, type EventFn, type Props } from "../typedefs.ts"
-import type { HTMLTagNameAttributesMap } from "./html_attributes_map.ts"
-import type { SVGTagNameAttributesMap } from "./svg_attributes_map.ts"
+import { HTMLElementUniqueMemberKeys, HTMLEventNames, HTMLTagNames, SVGEventNames, SVGTagNames, number_parseInt, object_assign, object_entries, object_fromEntries, } from "./deps.ts"
+import type { HTMLTagNameAttributesMap } from "./dom_core/html_attributes_map.ts"
+import type { SVGTagNameAttributesMap } from "./dom_core/svg_attributes_map.ts"
+import { ATTRS, AdvancedEventFn, EVENTS, EXECUTE, EventFn, MEMBERS, STYLE } from "./symbol_props.ts"
+import type { Props } from "./typedefs.ts"
 
 /** when explicitly declaring a prop to be of an attribute kind, use the `attr:` prefix to specify. <br>
  * examples: `attr:id`, `attr:style`, `attr:class`, and `attr:href`. <br>
@@ -28,9 +29,7 @@ import type { SVGTagNameAttributesMap } from "./svg_attributes_map.ts"
 */
 export type InlineAttrName<QualifiedAttributeNames extends string = string> = `attr:${QualifiedAttributeNames}`
 
-/** the function signature of functions executable via jsx {@link InlineExecuteName | `InlineExecuteName`},
- * right after the element has been created
-*/
+/** the function signature of functions executable via jsx {@link InlineExecuteName | `InlineExecuteName`}, right after the element has been created. */
 export type InlineExecuteFn<E extends Element = Element> = (new_element: E) => void
 
 /** when explicitly declaring function to execute right after the creation of the element, use the `exec:$` prefix to specify the order in which it should be ran. <br>
@@ -106,17 +105,16 @@ export type InlineEventName<QualifiedEventNames extends string = HTMLEventNames>
 */
 export type InlineMemberName<QualifiedMemberNames extends string = HTMLElementUniqueMemberKeys<any>> = `set:${QualifiedMemberNames}`
 
-type GenericInlineProps = {
+export interface InlineDefaultProps {
 	style?: any
 	[attribute_name: `attr:${string}`]: any
 	[execute_function_in_order: `exec:$${number}`]: any
 	[set_element_member: `set:${string}`]: any
 	[event_name: `on:${string}`]: any
 }
-// Record<| `style` | `on:${string}` | `set:${string}` | `attr:${string}` | `exec:$${number}`, any>
 
 /** remaps the inlined attributes/properties into their standard symbol fields, so that they become {@link Props} compliant. */
-export const inlinePropsRemapper = (props?: Props<GenericInlineProps> | any): Props<any> => {
+export const inlinePropsRemapper = (props?: Props<InlineDefaultProps> | any): Props<any> => {
 	const {
 		// [STYLE]: style_props, // do not use the `[STYLE]` symbol prop key for convenient renderers
 		style: style_props = {},

--- a/src/symbol_props.ts
+++ b/src/symbol_props.ts
@@ -1,0 +1,159 @@
+import { DEBUG, HTMLEventNames, PreserveStringKeyAndValues } from "./deps.ts"
+
+
+export const
+	/** the key used for explicitly declaring attribute props on the output of {@link ComponentGenerator | `ComponentGenerator`s}. */
+	ATTRS = Symbol(DEBUG.MINIFY || "explicitly declared Element attributes of a single Component"),
+	/** the key used for explicitly declaring event handling functions on the output of any {@link HyperRender.h | `Element Renderer`}. */
+	EVENTS = Symbol(DEBUG.MINIFY || "explicitly declared event listeners of a single Component"),
+	/** the key used for explicitly declaring advanced event handling functions on the output of any {@link HyperRender.h | `Element Renderer`}. */
+	ADVANCED_EVENTS = Symbol(DEBUG.MINIFY || "explicitly declared advaced configurable events of a single component"),
+	/** the key used for explicitly declaring member assignments to make on the generated output of any {@link HyperRender.h | `Element Renderer`}. */
+	MEMBERS = Symbol(DEBUG.MINIFY || "explicitly declared element member assignments to make"),
+	/** the key used for explicitly declaring style assignments to make on the generated output of any {@link HyperRender.h | `Element Renderer`}. */
+	STYLE = Symbol(DEBUG.MINIFY || "explicitly declared element style to apply"),
+	/** the key used for explicitly declaring an array of functions to execute on the generated output element of any {@link HyperRender.h | `Element Renderer`} as the first parameter. */
+	EXECUTE = Symbol(DEBUG.MINIFY || "explicitly declared list of functions to execute on the element itself after its creation")
+
+/** the default props assignable to all components (any renderer that inherits from {@link Component_Render | `Component_Render`} will support these). <br>
+ * see the details of each on their respective documentation:
+ * - for element attributes, see: {@link AttrProps | `AttrProps`}
+ * - for element events, see: {@link EventProps | `EventProps`}
+ * - for configurable element events, see: {@link AdvancedEventProps | `AdvancedEventProps`}
+ * - for element javascript members, see: {@link MemberProps | `MemberProps`}
+ * - for element dynamic styling, see: {@link StyleProps | `StyleProps`}
+ * - for running post-creation functions with the element as the parameter, see: {@link ExecuteProps | `SelfProps`}
+*/
+export interface DefaultProps {
+	[ATTRS]?: AttrProps | undefined | null
+	[EVENTS]?: EventProps | undefined | null
+	[ADVANCED_EVENTS]?: AdvancedEventProps | undefined | null
+	[MEMBERS]?: MemberProps | undefined | null
+	[STYLE]?: StyleProps | undefined | null
+	[EXECUTE]?: ExecuteProps | undefined | null
+}
+
+
+/** the props used for explicitly declaring attributes on the output of {@link ComponentGenerator | `ComponentGenerator`s}.
+ * 
+ * @example
+ * ```ts
+ * const CanvasComponent: ComponentGenerator<{
+ * 	width?: number,
+ * 	height?: number,
+ * }> = ({ width = 300, height = 300 }) => <canvas width={width} height={height}>canvas is not supported</canvas>
+ * const my_canvas = <CanvasComponent height={200} {...{
+ * 	[ATTRS]: {
+ * 		width: 400, // this later overrides the original value of `"300"` set by default.
+ * 		style: "background-color: green;", // assign a new attribute node for a green background.
+ * 	} as AttrProps
+ * }}>ddd</CanvasComponent>
+ * ```
+*/
+export type AttrProps = { [attr: string]: any }
+
+
+/** mapped dictionary of all standard HTMLEvents */
+export type EventFn<NAME extends HTMLEventNames> = (this: Element, event: HTMLElementEventMap[NAME]) => void
+
+export type AdvancedEventFn<NAME extends HTMLEventNames> = [event_fn: EventFn<NAME>, options?: boolean | AddEventListenerOptions]
+
+
+/** the props used for explicitly declaring event handler functions on the output of any {@link HyperRender.h | `Element Renderer`}.
+ * 
+ * @example
+ * ```tsx
+ * let triggered = false
+ * const my_button = <button {...{
+ * 	[EVENTS]: {
+ * 		click(event) {
+ * 			const element = event.currentTarget as HTMLButtonElement
+ * 			if (triggered) { element.attributeStyleMap.set("background-color", "red") }
+ * 			else { element.attributeStyleMap.set("background-color", "blue") }
+ * 			triggered = !triggered
+ * 		}
+ * 	} as EventProps
+ * }}>
+ * GET TRIGGERED
+ * </button>
+ * ```
+*/
+export type EventProps = {
+	[event_name in HTMLEventNames]?: EventFn<event_name>
+}
+
+
+/** the props used for explicitly declaring advanced event handler functions on the output of any {@link HyperRender.h | `Element Renderer`}. <br>
+ * each entry's value needs to be a 2-tuple of the event handler function (`event_fn`) and its configuration `option` (of type `AddEventListenerOptions`).
+ * 
+ * @example
+ * ```tsx
+ * const my_div = <div {...{
+ * 	[ADVANCED_EVENTS]: {
+ * 		click: [(event) => {
+ * 			console.log("user clicked at (x,y)-position:", event.clientX, event.clientY)
+ * 		}, { once: true, passive: true }]
+ * 	} as AdvancedEventProps
+ * }}>
+ * PLZZ CLICC ONN BIGG DIVV ONCEE ONLYY
+ * </div>
+ * ```
+*/
+export type AdvancedEventProps = {
+	[event_name in HTMLEventNames]?: [event_fn: EventFn<event_name>, options?: boolean | AddEventListenerOptions]
+}
+
+
+/** the props used for explicitly declaring member assignments to make on the generated output of any {@link HyperRender.h | `Element Renderer`}. <br>
+ * note that many intrinsic properties of certain HTMLElements, such as `value` and `checked`, are also reflected as their "attributes",
+ * but they are merely there for the purpose of initialization, and not actual mutation (although it does work in many cases). <br>
+ * still, it is best to modify the property of an element if it is an intrinsic feature of that element, rather than modifying its attributes,
+ * since the property holds the "real"/"true" value, and usually in a primitive javascript object format, rather than being exclusively a `string` or `null`.
+ * 
+ * @example
+ * ```tsx
+ * // assign `my_input.value = "hello"` and `my_input.disabled = true`
+ * const my_input = <input value="default value" {...{
+ * 	[MEMBERS]: {
+ * 		value: "hello",
+ * 		disabled: true,
+ * 	} as MemberProps<HTMLInputElement>
+ * }} />
+ * ```
+*/
+export type MemberProps<E = Element> = {
+	[member_key in keyof E]?: E[member_key]
+}
+
+
+export type CSSVarProps = { [var_name: `--${string}`]: string | undefined }
+
+/** standard CSS styling properties, along with variable property declaration support (i.e. `css_object["--my-var"]`) */
+export type StyleProps = Partial<PreserveStringKeyAndValues<CSSStyleDeclaration> & CSSVarProps>
+
+
+/** provide an array of functions to execute on the generated output of an {@link HyperRender.h | `Element Renderer`} as the first argument. <br>
+ * this is useful in cases where you may wish to register the element post-creation, or perhaps apply some mutations to the element itself.
+ * 
+ * @example
+ * ```tsx
+ * // apply some style to `my_div` post-creation
+ * const my_div = <div style="background-color: green;" {...{
+ * 	[EXECUTE]: [
+ * 		(div_element): void => {
+ * 			if(div_element.style.backgroundColor === "green") {
+ * 				div_element.style.backgroundColor = "red"
+ * 			}
+ * 		},
+ * 		(div_element): void => {
+ * 			if(div_element.style.backgroundColor === "red") {
+ * 				div_element.style.backgroundColor = "blue"
+ * 			}
+ * 		},
+ * 	] as ExecuteProps<HTMLDivElement>
+ * }}>
+ * I'm blue daba dee daba die, If I were green I would die.
+ * </div>
+ * ```
+*/
+export type ExecuteProps<E = Element> = Array<(element: E) => void>

--- a/src/typedefs.ts
+++ b/src/typedefs.ts
@@ -1,5 +1,48 @@
 import type { Component_Render } from "./core/mod.ts"
-import { DEBUG, HTMLEventNames, PreserveStringKeyAndValues, bindMethodToSelfByName } from "./deps.ts"
+import { DEBUG, bindMethodToSelfByName } from "./deps.ts"
+import { HyperZone } from "./hyperzone.ts"
+
+
+/// component generator definitions
+
+/** this is the base model for this library which must be extended by all JSX renders. */
+export abstract class HyperRender<TAG = any, OUTPUT = any> {
+	constructor(config?: any) { }
+
+	/** tests if the provided parameters, {@link tag | `tag`} and {@link props | `props`}, are compatible this `Zone`'s {@link h | `h` method} */
+	abstract test(tag: any, props?: any): boolean
+
+	/** creates an {@link OUTPUT | element} out of its properties. functions similar to `React.createElement` */
+	abstract h(tag: TAG, props?: null | { [key: PropertyKey]: any }, ...children: any[]): OUTPUT
+
+	/** convenience method for generating instance-bound closures out of prototype methods.
+	 * only for internal use.
+	*/
+	bindMethod<M extends keyof this>(method_name: M): this[M] {
+		return bindMethodToSelfByName(this as any, method_name) as this[M]
+	}
+}
+
+interface HyperRenderConfig {
+	hyperzone: HyperZone
+}
+
+/** the props accepted by any {@link ComponentGenerator}, as a single variable. */
+export type Props<P = {}> = P & DefaultProps
+
+/** a function that takes in a single {@link Props | `Props`} object variable, and generates a single HTML element. */
+export type SingleComponentGenerator<P = {}> = (props: Props<P>) => Element
+
+/** a function that takes in a single {@link Props | `Props`} object variable, and generates an array of HTML elements (aka a fragment). */
+export type FragmentComponentGenerator<P = {}> = (props: P) => (string | Element)[]
+
+/** a function that takes in a single {@link Props | `Props`} object variable, and generates either a single HTML element or an array of them. */
+export type ComponentGenerator<P = {}> = SingleComponentGenerator<P> | FragmentComponentGenerator<P>
+
+export const Fragment = Symbol(DEBUG.MINIFY || "indicator for a fragment component")
+
+
+/// utility definitions
 
 /** any object or primitive that implements the `toString` method. */
 export type Stringifiable = { toString(): string }
@@ -24,184 +67,3 @@ export type AttrValue = Stringifiable | AttrTruthy | AttrFalsy
 
 /** the value assignable to any `TextNode` */
 export type TextValue = Stringifiable | null | undefined
-
-/** this is the base model for this library which must be extended by all JSX renders. */
-export abstract class HyperRender<TAG = any, OUTPUT = any> {
-	/** tests if the provided parameters, {@link tag | `tag`} and {@link props | `props`}, are compatible this `Zone`'s {@link h | `h` method} */
-	abstract test(tag: any, props?: any): boolean
-
-	/** creates an {@link OUTPUT | element} out of its properties. functions similar to `React.createElement` */
-	abstract h(tag: TAG, props?: null | { [key: PropertyKey]: any }, ...children: any[]): OUTPUT
-
-	/** convenience method for generating instance-bound closures out of prototype methods.
-	 * only for internal use.
-	*/
-	bindMethod<M extends keyof this>(method_name: M): this[M] {
-		return bindMethodToSelfByName(this as any, method_name) as this[M]
-	}
-}
-
-/** the key used for explicitly declaring attribute props on the output of {@link ComponentGenerator | `ComponentGenerator`s}. */
-export const ATTRS = Symbol(DEBUG.MINIFY || "explicitly declared Element attributes of a single Component")
-
-/** the props used for explicitly declaring attributes on the output of {@link ComponentGenerator | `ComponentGenerator`s}.
- * 
- * @example
- * ```ts
- * const CanvasComponent: ComponentGenerator<{
- * 	width?: number,
- * 	height?: number,
- * }> = ({ width = 300, height = 300 }) => <canvas width={width} height={height}>canvas is not supported</canvas>
- * const my_canvas = <CanvasComponent height={200} {...{
- * 	[ATTRS]: {
- * 		width: 400, // this later overrides the original value of `"300"` set by default.
- * 		style: "background-color: green;", // assign a new attribute node for a green background.
- * 	} as AttrProps
- * }}>ddd</CanvasComponent>
- * ```
-*/
-export type AttrProps = { [attr: string]: any }
-
-/** mapped dictionary of all standard HTMLEvents */
-export type EventFn<NAME extends HTMLEventNames> = (this: Element, event: HTMLElementEventMap[NAME]) => void
-
-export type AdvancedEventFn<NAME extends HTMLEventNames> = [event_fn: EventFn<NAME>, options?: boolean | AddEventListenerOptions]
-
-/** the key used for explicitly declaring event handling functions on the output of any {@link HyperRender.h | `Element Renderer`}. */
-export const EVENTS = Symbol(DEBUG.MINIFY || "explicitly declared event listeners of a single Component")
-
-/** the props used for explicitly declaring event handler functions on the output of any {@link HyperRender.h | `Element Renderer`}.
- * 
- * @example
- * ```tsx
- * let triggered = false
- * const my_button = <button {...{
- * 	[EVENTS]: {
- * 		click(event) {
- * 			const element = event.currentTarget as HTMLButtonElement
- * 			if (triggered) { element.attributeStyleMap.set("background-color", "red") }
- * 			else { element.attributeStyleMap.set("background-color", "blue") }
- * 			triggered = !triggered
- * 		}
- * 	} as EventProps
- * }}>
- * GET TRIGGERED
- * </button>
- * ```
-*/
-export type EventProps = {
-	[event_name in HTMLEventNames]?: EventFn<event_name>
-}
-
-/** the key used for explicitly declaring advanced event handling functions on the output of any {@link HyperRender.h | `Element Renderer`}. */
-export const ADVANCED_EVENTS = Symbol(DEBUG.MINIFY || "explicitly declared advaced configurable events of a single component")
-
-/** the props used for explicitly declaring advanced event handler functions on the output of any {@link HyperRender.h | `Element Renderer`}. <br>
- * each entry's value needs to be a 2-tuple of the event handler function (`event_fn`) and its configuration `option` (of type `AddEventListenerOptions`).
- * 
- * @example
- * ```tsx
- * const my_div = <div {...{
- * 	[ADVANCED_EVENTS]: {
- * 		click: [(event) => {
- * 			console.log("user clicked at (x,y)-position:", event.clientX, event.clientY)
- * 		}, { once: true, passive: true }]
- * 	} as AdvancedEventProps
- * }}>
- * PLZZ CLICC ONN BIGG DIVV ONCEE ONLYY
- * </div>
- * ```
-*/
-export type AdvancedEventProps = {
-	[event_name in HTMLEventNames]?: [event_fn: EventFn<event_name>, options?: boolean | AddEventListenerOptions]
-}
-
-/** the key used for explicitly declaring member assignments to make on the generated output of any {@link HyperRender.h | `Element Renderer`}. */
-export const MEMBERS = Symbol(DEBUG.MINIFY || "explicitly declared element member assignments to make")
-
-/** the props used for explicitly declaring member assignments to make on the generated output of any {@link HyperRender.h | `Element Renderer`}. <br>
- * note that many intrinsic properties of certain HTMLElements, such as `value` and `checked`, are also reflected as their "attributes",
- * but they are merely there for the purpose of initialization, and not actual mutation (although it does work in many cases). <br>
- * still, it is best to modify the property of an element if it is an intrinsic feature of that element, rather than modifying its attributes,
- * since the property holds the "real"/"true" value, and usually in a primitive javascript object format, rather than being exclusively a `string` or `null`.
- * 
- * @example
- * ```tsx
- * // assign `my_input.value = "hello"` and `my_input.disabled = true`
- * const my_input = <input value="default value" {...{
- * 	[MEMBERS]: {
- * 		value: "hello",
- * 		disabled: true,
- * 	} as MemberProps<HTMLInputElement>
- * }} />
- * ```
-*/
-export type MemberProps<E = Element> = {
-	[member_key in keyof E]?: E[member_key]
-}
-
-/** the key used for explicitly declaring style assignments to make on the generated output of any {@link HyperRender.h | `Element Renderer`}. */
-export const STYLE = Symbol(DEBUG.MINIFY || "explicitly declared element style to apply")
-export type CSSVarProps = { [var_name: `--${string}`]: string | undefined }
-export type StyleProps = Partial<PreserveStringKeyAndValues<CSSStyleDeclaration> & CSSVarProps>
-
-/** the key used for explicitly declaring an array of functions to execute on the generated output element of any {@link HyperRender.h | `Element Renderer`} as the first parameter. */
-export const EXECUTE = Symbol(DEBUG.MINIFY || "explicitly declared list of functions to execute on the element itself after its creation")
-
-/** provide an array of functions to execute on the generated output of an {@link HyperRender.h | `Element Renderer`} as the first argument. <br>
- * this is useful in cases where you may wish to register the element post-creation, or perhaps apply some mutations to the element itself.
- * 
- * @example
- * ```tsx
- * // apply some style to `my_div` post-creation
- * const my_div = <div style="background-color: green;" {...{
- * 	[EXECUTE]: [
- * 		(div_element): void => {
- * 			if(div_element.style.backgroundColor === "green") {
- * 				div_element.style.backgroundColor = "red"
- * 			}
- * 		},
- * 		(div_element): void => {
- * 			if(div_element.style.backgroundColor === "red") {
- * 				div_element.style.backgroundColor = "blue"
- * 			}
- * 		},
- * 	] as ExecuteProps<HTMLDivElement>
- * }}>
- * I'm blue daba dee daba die, If I were green I would die.
- * </div>
- * ```
-*/
-export type ExecuteProps<E = Element> = Array<(element: E) => void>
-
-/** the default props assignable to all components (any renderer that inherits from {@link Component_Render | `Component_Render`} will support these). <br>
- * see the details of each on their respective documentation:
- * - for element attributes, see: {@link AttrProps | `AttrProps`}
- * - for element events, see: {@link EventProps | `EventProps`}
- * - for configurable element events, see: {@link AdvancedEventProps | `AdvancedEventProps`}
- * - for element javascript members, see: {@link MemberProps | `MemberProps`}
- * - for element dynamic styling, see: {@link StyleProps | `StyleProps`}
- * - for running post-creation functions with the element as the parameter, see: {@link ExecuteProps | `SelfProps`}
-*/
-export interface DefaultProps {
-	[ATTRS]?: AttrProps | undefined | null
-	[EVENTS]?: EventProps | undefined | null
-	[ADVANCED_EVENTS]?: AdvancedEventProps | undefined | null
-	[MEMBERS]?: MemberProps | undefined | null
-	[STYLE]?: StyleProps | undefined | null
-	[EXECUTE]?: ExecuteProps | undefined | null
-}
-
-/** the props accepted by any {@link ComponentGenerator}, as a single variable. */
-export type Props<P = {}> = P & DefaultProps
-
-/** a function that takes in a single {@link Props | `Props`} object variable, and generates a single HTML element. */
-export type SingleComponentGenerator<P = {}> = (props: Props<P>) => Element
-
-/** a function that takes in a single {@link Props | `Props`} object variable, and generates an array of HTML elements (aka a fragment). */
-export type FragmentComponentGenerator<P = {}> = (props: P) => (string | Element)[]
-
-/** a function that takes in a single {@link Props | `Props`} object variable, and generates either a single HTML element or an array of them. */
-export type ComponentGenerator<P = {}> = SingleComponentGenerator<P> | FragmentComponentGenerator<P>
-
-export const Fragment = Symbol(DEBUG.MINIFY || "indicator for a fragment component")


### PR DESCRIPTION
draft of a temporary backup of where I left off, before trying it another way.
I may have added extra documentation comments in between, and in order to preserve those which I've not copied over, I'm making this PR.

what I'm trying to achieve:
- have separate declaration files for inline props and symbolic props.
- make both props mapped types compatible with each other.
- make them both provide factory types for creating `InterinsicElements`, based on the user's provided framework types
- `HyperRender` should now have a constructor that takes an optional config parameter, and all frameworks should accept the `config.hyperscript: s HyperZone` optional constructor parameter in order to either obtain a pre-existing framework-specific context or sideload their own into the `HyperZone`
- remove the class factory construction of the tsignal reactive component renderer classes, and replace them with a class that accepts the hyperzone as an optional parameter to load its `tsignal.Context` from.